### PR TITLE
Added password length validation check.

### DIFF
--- a/PSGitLab/Public/User/New-GitLabUser.ps1
+++ b/PSGitLab/Public/User/New-GitLabUser.ps1
@@ -14,6 +14,7 @@ Function New-GitLabUser {
         [string]$Email,
 
         [ValidateNotNullOrEmpty()]
+        [ValidatePattern("(?# Error: Password Must Contain at least 8 characters).{8,}")]
         [Parameter(Mandatory=$true)]
         [string]$Password,
 


### PR DESCRIPTION
Uses the validation regex to make sure the character minimum is set. If we ever find better defined rules for passwords we can update this regex. 

Note: The error it gives kind of sucks. Added a regex comment to give the user more information. 

Resolve #69 
