### PR TITLE
bugfix 400 BAD REQUEST

### DIFF
--- a/PSGitLab/Public/MergeRequests/Set-GitLabMergeRequest.ps1
+++ b/PSGitLab/Public/MergeRequests/Set-GitLabMergeRequest.ps1
@@ -20,20 +20,20 @@ Function Set-GitLabMergeRequest {
         [Parameter(ValueFromPipelineByPropertyName,Mandatory)]
         [string[]]$ID,
 
-        [string]$TargetBranch = $null,
+        [string]$TargetBranch,
 
-        [string]$AssigneeId = $null,
+        [string]$AssigneeId,
 
-        [string]$Title = $null,
+        [string]$Title,
 
-        [string]$Description = $null,
+        [string]$Description,
 
         [ValidateSet("close", "reopen", "merge")]
-        [string]$StateEvent = $null,
+        [string]$StateEvent,
 
-        [string]$Labels = $null,
+        [string]$Labels,
 
-        [string]$MilestoneId = $null,
+        [string]$MilestoneId,
 
         [switch]$Passthru
 
@@ -52,25 +52,25 @@ PROCESS {
 
         $GetUrlParameters = @()
 
-        if ($TargetBranch -ne $null) {
+        if ($TargetBranch) {
             $GetUrlParameters += @{target_branch=$TargetBranch}
         }
-        if ($AssigneeId -ne $null) {
+        if ($AssigneeId) {
             $GetUrlParameters += @{assignee_id=$AssigneeId}
         }
-        if ($Title -ne $null) {
+        if ($Title) {
             $GetUrlParameters += @{title=$Title}
         }
-        if ($Description -ne $null) {
+        if ($Description) {
             $GetUrlParameters += @{description=$Description}
         }
-        if ($StateEvent -ne $null) {
+        if ($StateEvent) {
             $GetUrlParameters += @{state_event=$StateEvent}
         }
-        if ($Labels -ne $null) {
+        if ($Labels) {
             $GetUrlParameters += @{labels=$Labels}
         }
-        if ($MilestoneId -ne $null) {
+        if ($MilestoneId) {
             $GetUrlParameters += @{milestone_id=$MilestoneId}
         }
 

--- a/PSGitLab/Public/Milestones/Set-GitLabMilestone.ps1
+++ b/PSGitLab/Public/Milestones/Set-GitLabMilestone.ps1
@@ -20,15 +20,15 @@ Function Set-GitLabMilestone {
         [Parameter(ValueFromPipelineByPropertyName,Mandatory)]
         [string[]]$ID,
 
-        [string]$Title = $null,
+        [string]$Title,
 
-        [string]$Description = $null,
+        [string]$Description,
 
-        [Nullable[datetime]]$DueDate = $null,
+        [Nullable[datetime]]$DueDate,
 
         [Alias('state_event')]
         [ValidateSet("close", "activate")]
-        [string]$StateEvent = $null
+        [string]$StateEvent
     )
 
 BEGIN {} 
@@ -44,16 +44,16 @@ PROCESS {
 
         $GetUrlParameters = @()
 
-        if ($Title -ne $null) {
+        if ($Title) {
             $GetUrlParameters += @{title=$Title}
         }
-        if ($Description -ne $null) {
+        if ($Description) {
             $GetUrlParameters += @{description=$Description}
         }
-        if ($DueDate -ne $null) {
+        if ($DueDate) {
             $GetUrlParameters += @{due_date=$DueDate.ToString("yyyy-MM-dd")}
         }
-        if ($StateEvent -ne $null) {
+        if ($StateEvent) {
             $GetUrlParameters += @{state_event=$StateEvent}
         }
 


### PR DESCRIPTION
I got a 400 Bad Request response on using `Set-GitLabMergeRequest`.

I realised that the function `Set-GitLabMergeRequest` sends all parameters (even they are empty). So the request was: `http://gitlab.localdomain.local/api/v3/projects/8/merge_requests/59?target_branch=&assignee_id=&title=my%20merge%20request%20title&description=&state_event=&labels=&milestone_id=`

I fixed that now - also for the function `Set-GitLabMilestone`.