### PR TITLE
Add SSH keys for different users

### DIFF
--- a/PSGitLab/PSGitLab.psd1
+++ b/PSGitLab/PSGitLab.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSGitLab.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.5.3'
+ModuleVersion = '2.5.4'
 
 # ID used to uniquely identify this module
 GUID = 'f844db87-fda8-403b-a7da-bdc00a3f5a58'

--- a/PSGitLab/Public/Keys/New-GitLabUserKey.ps1
+++ b/PSGitLab/Public/Keys/New-GitLabUserKey.ps1
@@ -9,8 +9,22 @@ Function New-GitLabUserKey {
         [string]$Key,
 
         [Parameter(ParameterSetName='File',Mandatory=$true)]
-        [string]$KeyFile = $null
+        [string]$KeyFile = $null,
+
+        [Parameter(Mandatory=$false)]
+        $Username = $null
     )
+
+    if ( $PSBoundParameters.ContainsKey('Username') ) {
+        try {
+            $User = Get-GitLabUser -Username $Username
+        } catch {
+            Write-Error "Unable to find user"
+        }
+        $URI = '/users/{0}/keys' -f $User.ID
+    } else {
+        $URI = "/user/keys"
+    }
 
     if ( $PSCmdlet.ParameterSetName -eq 'File' ) {
         $Contents = Get-Content -Path $KeyFile 
@@ -30,10 +44,11 @@ Function New-GitLabUserKey {
     }
 
     $Request = @{
-        URI="/user/keys";
-        Method='POST';
+        URI=$URI;
+        Method='POST'
         Body = $Body
     }
+
 
    
     QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User.Key'      

--- a/docs/New-GitLabUserKey.md
+++ b/docs/New-GitLabUserKey.md
@@ -1,28 +1,29 @@
 ---
 external help file: PSGitLab-help.xml
-online version: 
+online version: https://docs.gitlab.com/ce/api/projects.html#hooks
 schema: 2.0.0
 ---
 
 # New-GitLabUserKey
 
 ## SYNOPSIS
-Creates new SSH Key for the current or another user. 
+Creates new SSH Key for the current or another user.
 
 ## SYNTAX
 
 ### Explicit (Default)
 ```
-New-GitLabUserKey [-Title <String>] -Key <String>
+New-GitLabUserKey [-Title <String>] -Key <String> [-Username <Object>]
 ```
 
 ### File
 ```
-New-GitLabUserKey -KeyFile <String>
+New-GitLabUserKey -KeyFile <String> [-Username <Object>]
 ```
 
 ## DESCRIPTION
-Creates new SSH Key for the current or another user. For another user, admin rights are required. 
+Creates new SSH Key for the current or another user.
+For another user, admin rights are required.
 
 ## EXAMPLES
 
@@ -31,7 +32,7 @@ Creates new SSH Key for the current or another user. For another user, admin rig
 PS C:\> New-GitLabUserKey -Title "Fake" -Key "ssh-rsa lkasjflkjasdf...."
 ```
 
-Create a new key from the command prompt. 
+Create a new key from the command prompt.
 
 ### Example 2
 ```
@@ -43,7 +44,7 @@ Add a key from a keyfile.
 ## PARAMETERS
 
 ### -Key
-A string representation of the SSH key. 
+A string representation of the SSH key.
 
 ```yaml
 Type: String
@@ -73,7 +74,7 @@ Accept wildcard characters: False
 ```
 
 ### -Title
-The title of the SSH key. 
+The title of the SSH key.
 
 ```yaml
 Type: String
@@ -87,15 +88,28 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Username
+The username of the user you would like to add the SSH key for. 
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ## INPUTS
 
 ### None
 
-
 ## OUTPUTS
 
 ### GitLab.User.Key
-
 
 ## NOTES
 


### PR DESCRIPTION
* Added the functionality to New-Gitlabuserkey to be able to add SSH keys for users.

* Added documentation for the changes

* Bumped the version number.

Fix #114