### PR TITLE
Add -RemoveSourceBranch switch parameter to New-GitLabMergeRequest

### DIFF
--- a/PSGitLab/Public/MergeRequests/New-GitLabMergeRequest.ps1
+++ b/PSGitLab/Public/MergeRequests/New-GitLabMergeRequest.ps1
@@ -12,7 +12,7 @@ Function New-GitLabMergeRequest {
         [ValidateNotNullOrEmpty()]
         [Parameter(Mandatory)]
         [string]$TargetBranch,
-        
+
         [int]$AssigneeId,
 
         [ValidateNotNullOrEmpty()]
@@ -25,7 +25,9 @@ Function New-GitLabMergeRequest {
 
         [string]$Labels,
 
-        [string]$MilestoneId
+        [string]$MilestoneId,
+
+        [switch]$RemoveSourceBranch
     )
 
     $Project = $Project = Get-GitlabProject -Id $ProjectId;
@@ -49,6 +51,9 @@ Function New-GitLabMergeRequest {
     }
     if ($MilestoneId) {
         $GetUrlParameters += @{milestone_id=$MilestoneId}
+    }
+    if ($RemoveSourceBranch) {
+        $GetUrlParameters += @{remove_source_branch=$true}
     }
 
     $URLParameters = GetMethodParameters -GetURLParameters $GetUrlParameters


### PR DESCRIPTION
When using this switch parameter, the merge request submitted to GitLab will have the option to remove the source branch on merge selected automatically.