### PR TITLE
Add support for GitLab runners

### DIFF
--- a/PSGitLab/PSGitLab.psd1
+++ b/PSGitLab/PSGitLab.psd1
@@ -114,7 +114,13 @@ FunctionsToExport = @(
     'Get-GitLabProjectArchive',
     'Get-GitLabProjectRepositoryTree',
     'Get-GitLabSetting',
-    'Get-GitLabVersion'
+    'Get-GitLabVersion',
+    'Add-GitLabProjectRunner',
+    'Get-GitLabRunner',
+    'New-GitLabRunner',
+    'Remove-GitLabProjectRunner', 
+    'Remove-GitLabRunner',
+    'Set-GitLabRunner' 
     )
 
 # Cmdlets to export from this module

--- a/PSGitLab/Public/Runners/Add-GitLabProjectRunner.ps1
+++ b/PSGitLab/Public/Runners/Add-GitLabProjectRunner.ps1
@@ -1,0 +1,21 @@
+﻿Function Add-GitLabProjectRunner {
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]$RunnerId,
+        
+        [Parameter(Mandatory=$true)]
+        [int]$ProjectId)
+        
+    $Body = @{
+        runner_id  = $RunnerId
+    }
+
+    $Request = @{
+        URI="/projects/$ProjectId/runners";
+        Method='POST';
+        Body=$Body;
+        ContentType='application/x-www-form-urlencoded';
+    }
+
+    QueryGitLabAPI -Request $Request -ObjectType 'GitLab.Runner'
+}

--- a/PSGitLab/Public/Runners/Get-GitLabRunner.ps1
+++ b/PSGitLab/Public/Runners/Get-GitLabRunner.ps1
@@ -1,0 +1,57 @@
+﻿Function Get-GitLabRunner {
+    [cmdletbinding(DefaultParameterSetName='Single')]
+    [OutputType("GitLab.Runner")]
+    param(
+        [Parameter(ParameterSetName='Single',
+                   Mandatory=$true)]
+        [int]$Id,
+
+        [Parameter(ParameterSetName='Project',
+                   Mandatory=$true)]
+        [int]$ProjectId,
+
+        [Parameter(ParameterSetName='Owned',
+                   Mandatory=$true)]
+        [switch]$Owned,
+
+        [Parameter(ParameterSetName='All',
+                   Mandatory=$true)]
+        [switch]$All,
+        
+        [Parameter(Mandatory=$false,
+                   HelpMessage='Limit by scope',
+                   ParameterSetName='Owned')]
+        [Parameter(Mandatory=$false,
+                   HelpMessage='Limit by scope',
+                   ParameterSetName='All')]
+        [ValidateSet("active", "paused", "online")]
+        $Scope = $null
+    )
+
+    if ($PSCmdlet.ParameterSetName -ne 'Single') {
+        Write-Verbose "Create GET Request"
+        $GetUrlParameters = @()
+        if ($Scope) {
+            $GetUrlParameters += @{scope=$Scope}
+        }
+
+        $URLParameters = GetMethodParameters -GetURLParameters $GetUrlParameters
+        Write-Host $URLParameters
+    }
+
+    $Request = @{
+        URI = ''
+        Method = 'GET'
+    }
+
+    Write-Verbose "Parameter Set Name: $($PSCmdlet.ParameterSetName)"
+
+    switch ($PSCmdlet.ParameterSetName) {
+        Single { $Request.URI = "/runners/$Id"; break; }
+        Owned { $Request.URI = "/runners/$URLParameters"; break; }
+        All { $Request.URI="/runners/all$URLParameters"; break; }
+        Project { $Request.URI="/projects/$ProjectId/runners"; break; }
+    }
+    
+    QueryGitLabAPI -Request $Request -ObjectType 'GitLab.Runner'
+}

--- a/PSGitLab/Public/Runners/New-GitLabRunner.ps1
+++ b/PSGitLab/Public/Runners/New-GitLabRunner.ps1
@@ -1,0 +1,76 @@
+﻿Function New-GitLabRunner {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $Token,
+
+        [Parameter(Mandatory=$true)]
+        [string] $Description,
+
+        [Parameter(Mandatory=$true)]
+        [string] $Tags,
+        
+        [bool] $RunUntagged = $false,
+        [bool] $Locked = $true,
+
+        [Parameter(Mandatory=$true)]
+        [string] $Platform = "linux",
+
+        [Parameter(Mandatory=$true)]
+        [string] $Architecture = "amd64",
+        
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("shell", "docker", "docker-ssh", "ssh", "parallels", "virtualbox", "docker+machine", "docker-ssh+machine", "kubernetes")]
+        [string] $Executor = "shell",
+
+        [bool] $Artifacts = $true,
+        [bool] $Cache = $true,
+        [bool] $Image = $true,
+        [bool] $Services = $true,
+        [bool] $Shared = $true,
+        [bool] $Variables = $true,
+        
+        [Parameter(Mandatory=$true)]
+        [string] $Name,
+        
+        [Parameter(Mandatory=$true)]
+        [string] $Revision = "c1ecf97f",
+        
+        [Parameter(Mandatory=$true)]
+        [string] $Version = "10.1.0"
+    )
+
+    $requestObject = @{
+        "info" = @{
+            "name" = $Name;
+            "version" = $Version;
+            "revision" = $Revision;
+            "platform" = $Platform;
+            "architecture" = $Architecture;
+            "executor" = $Executor;
+            "features" = @{
+                "variables" = $Variables;
+                "image" = $Image;
+                "services" = $Services;
+                "artifacts" = $Artifacts;
+                "cache" = $Cache;
+                "shared" = $Shared;
+            };
+        };
+        "token" = $Token;
+        "description" = $Description;
+        "tag_list" = $Tags;
+        "run_untagged" = $RunUntagged;
+        "locked" = $locked;
+    }
+
+    $Body = ConvertTo-Json $requestObject
+
+    $Request = @{
+        URI='/runners';
+        Method='POST';
+        Body=$Body;
+        ContentType="application/json"
+    }
+
+    QueryGitLabAPI -Request $Request -ObjectType 'GitLab.Runner'
+}

--- a/PSGitLab/Public/Runners/Remove-GitLabProjectRunner.ps1
+++ b/PSGitLab/Public/Runners/Remove-GitLabProjectRunner.ps1
@@ -1,0 +1,15 @@
+﻿Function Remove-GitLabProjectRunner {
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]$RunnerId,
+        
+        [Parameter(Mandatory=$true)]
+        [int]$ProjectId)
+
+    $Request = @{
+        URI="/projects/$ProjectId/runners/$RunnerId";
+        Method='DELETE';
+    }
+
+    QueryGitLabAPI -Request $Request -ObjectType 'GitLab.Runner'
+}

--- a/PSGitLab/Public/Runners/Remove-GitLabRunner.ps1
+++ b/PSGitLab/Public/Runners/Remove-GitLabRunner.ps1
@@ -1,0 +1,12 @@
+﻿Function Remove-GitLabRunner {
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]$Id)
+
+    $Request = @{
+        URI="/runners/$Id";
+        Method='DELETE';
+    }
+
+    QueryGitLabAPI -Request $Request -ObjectType 'GitLab.Runner'
+}

--- a/PSGitLab/Public/Runners/Set-GitLabRunner.ps1
+++ b/PSGitLab/Public/Runners/Set-GitLabRunner.ps1
@@ -1,0 +1,43 @@
+﻿Function Set-GitLabRunner {
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]$Id,
+        
+        [string]$Description,
+        
+        # See http://itproctology.blogspot.be/2014/03/powershell-passing-empty-parameters-and.html
+        # for the rationale for this
+        [ValidateSet("True","False","", 0, 1)]
+        [string]$Active,
+        [string]$Tags,
+        
+        [ValidateSet("True","False","", 0, 1)]
+        [string]$RunUntagged,
+        
+        [ValidateSet("True","False","", 0, 1)]
+        [string]$Locked,
+
+        [ValidateSet("not_protected", "ref_protected")]
+        [string]$AccessLevel)
+
+    $Body = @{}
+
+    
+    if ($Description) { $Body.Add('description',$Description) }
+    if ($Active) { $Body.Add('active',$active) }
+    if ($Tags) { $Body.Add('tag_list', $Tags) }
+    if ($RunUntagged) { $Body.Add('run_untagged', $RunUntagged) }
+    if ($Locked) {$Body.Add('locked', $Locked) }
+    if ($AccessLevel) { $Body.Add('access_level', $AccessLevel) }
+
+    Write-Host (ConvertTo-Json $Body)
+
+    $Request = @{
+        URI="/runners/$Id";
+        Method='PUT';
+        Body=$Body;
+        ContentType='application/x-www-form-urlencoded';
+    }
+
+    QueryGitLabAPI -Request $Request -ObjectType 'GitLab.Runner'
+}

--- a/docs/Add-GitLabProjectRunner.md
+++ b/docs/Add-GitLabProjectRunner.md
@@ -1,0 +1,43 @@
+---
+external help file: PSGitLab-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Add-GitLabProjectRunner
+
+## SYNOPSIS
+Enable an available specific runner in the project.
+
+## SYNTAX
+
+```
+Add-GitLabProjectRunner -RunnerId <int> -ProjectId <int>
+```
+
+## DESCRIPTION
+Enable an available specific runner in the project.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Add-GitLabProjectRunner -RunnerId 400 -ProjectId 500
+```
+
+## PARAMETERS
+
+### -RunnerId
+The ID of the GitLab runner to enable on the project.
+
+### -ProjectId
+The ID of the project on which to enable the runner.
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+[Enable a runner in a project](https://docs.gitlab.com/ce/api/runners.html#enable-a-runner-in-project)

--- a/docs/Get-GitLabRunner.md
+++ b/docs/Get-GitLabRunner.md
@@ -1,0 +1,83 @@
+---
+external help file: PSGitLab-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Get-GitLabRunner
+
+## SYNOPSIS
+Retrieve all runner in a GitLab instance.
+
+## SYNTAX
+
+### Single (Default)
+```
+Get-GitLabRunner -Id <Int32>
+```
+
+### Project (Default)
+```
+Get-GitLabRunner -ProjectId <Int32>
+```
+
+### Owned
+```
+Get-GitLabRunner -Owned [-State <String>]
+```
+
+### All
+```
+Get-GitLabProject -All [-State <String>]
+```
+
+## DESCRIPTION
+Retrieve all runners in a GitLab instance.
+Queries over HTTP and gets back GitLab.Project type.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Get-GitLabRunner -All
+```
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+Get-GitLabRunner -Owned
+```
+
+### -------------------------- EXAMPLE 3 --------------------------
+```
+Get-GitLabRunner -Id 4
+```
+
+## PARAMETERS
+
+### -Id
+The ID of the runner.
+
+### -ProjectId
+The ID of the project for which to list all runners.
+
+### -Owned
+Return all owned runners.
+
+### -All
+Return all available runners.
+
+### -Scope
+Limits the scope of runners to return.
+
+## INPUTS
+
+## OUTPUTS
+
+### GitLab.Runner
+
+## NOTES
+
+## RELATED LINKS
+[Get runner details](https://docs.gitlab.com/ce/api/runners.html#get-runner-s-details)
+[List owned runners](https://docs.gitlab.com/ce/api/runners.html#list-owned-runners)
+[List all runners](https://docs.gitlab.com/ce/api/runners.html#list-all-runners)

--- a/docs/New-GitLabRunner.md
+++ b/docs/New-GitLabRunner.md
@@ -1,0 +1,79 @@
+---
+external help file: PSGitLab-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# New-GitLabRunner
+
+## SYNOPSIS
+Creates a new GitLab runner.
+
+## SYNTAX
+
+```
+New-GitLabRunner -Token <string> -Description <string> -Tags <string> [-RunUntagged <bool>] [-Locked <bool>] [-Platform <string>] [-Architecture <string>] [-Executor <string>] [-Artifacts <bool>] [-Cache <bool>] [-Image <bool>] [-Services <bool>] [-Shared <bool>] [-Variables <bool>] -Name <string> -Revision <string> -Version <string>
+```
+
+## DESCRIPTION
+Creates a new GitLab runner.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+New-GitLabRunner -Token T0k3n -Name "Quamotion" -Description "Quamotion" -Tags "quamotion" -Platform linux -Architecture amd64 -Executor shell -Revision c1ecf97f -Version "10.1.0"
+```
+
+## PARAMETERS
+
+### -token
+The runner registration token.
+
+### -name
+The name for the runner.
+
+### -description
+A description of the runner.
+
+### -tags
+A comma-delimited list of tags to assign to the runner.
+
+### -platform
+The platform which hosts this runner, such as Windows or Linux.
+
+### -architecture
+The CPU architecture of the platform which hosts this runner, such as AMD64.
+
+### -executor
+The executor which this runner uses.
+
+### -artifacts
+Whether this runner supports artifacts.
+
+### -cache
+Whether this runner supports caching.
+
+### -image
+Whether this runner support images.
+
+### -shared
+Whether this runner is shared.
+
+### -variables
+Whether this runner supports variables.
+
+### -revision
+The revision of the runner software.
+
+### -version
+The version of the runner software.
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/docs/Remove-GitLabProjectRunner.md
+++ b/docs/Remove-GitLabProjectRunner.md
@@ -1,0 +1,46 @@
+---
+external help file: PSGitLab-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Remove-GitLabProjectRunner
+
+## SYNOPSIS
+Disable a specific runner from the project. 
+
+## SYNTAX
+
+```
+Remove-GitLabProjectRunner -RunnerId <int> -ProjectId <int>
+```
+
+## DESCRIPTION
+Disable a specific runner from the project.
+Works only if the project isn't the only project associated with the specified runner.
+If so, an error is returned. Use the Remove-GitLabRunner instead.
+
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Remove-GitLabProjectRunner -RunnerId 400 -ProjectId 500
+```
+
+## PARAMETERS
+
+### -RunnerId
+The ID of the GitLab runner to disable on the project.
+
+### -ProjectId
+The ID of the project on which to disable the runner.
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+[Disable a runner in a project](https://docs.gitlab.com/ce/api/runners.html#disable-a-runner-from-project)

--- a/docs/Remove-GitLabRunner.md
+++ b/docs/Remove-GitLabRunner.md
@@ -1,0 +1,40 @@
+---
+external help file: PSGitLab-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Remove-GitLabRunner
+
+## SYNOPSIS
+Removes a runner.
+
+## SYNTAX
+
+```
+Remove-GitLabRunner -Id <int>
+```
+
+## DESCRIPTION
+Removes a runner from GitLab.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Remove-GitLabRunner -Id 400
+```
+
+## PARAMETERS
+
+### -Id
+The ID of the GitLab runner to remove.
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+[Remove a runner](https://docs.gitlab.com/ce/api/runners.html#remove-a-runner)

--- a/docs/Set-GitLabRunner.md
+++ b/docs/Set-GitLabRunner.md
@@ -1,0 +1,58 @@
+---
+external help file: PSGitLab-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Set-GitLabRunner
+
+## SYNOPSIS
+Updates a runner's details.
+
+## SYNTAX
+
+```
+Set-GitLabRunner -Id <int> -Description <string> -Active <bool> -Tags <string> -RunUntagged <bool> -Locked <bool> -AccessLevel [not_protected|ref_protected]
+```
+
+## DESCRIPTION
+Updates a runner's details.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Set-GitLabRunner -Id 400 -Active $true -Locked $false
+```
+
+## PARAMETERS
+
+### -Id
+The ID of the GitLab runner to update.
+
+### -Description
+The description of a runner.
+
+### -Active
+The state of a runner; can be set to true or false.
+
+### -Tags
+The comma-separated list of tags for a runner.
+
+### -RunUntagged
+Flag indicating the runner can execute untagged jobs.
+
+### -Locked
+Flag indicating the runner is locked to the current project.
+
+### -AccessLevel
+The access level of the runner; not_protected or ref_protected
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+[Update runner's details](https://docs.gitlab.com/ce/api/runners.html#update-runner-s-details)


### PR DESCRIPTION
This PR adds support for managing GitLab runners via PowerShell.

You can:
- Add, get, list, update and remove runners
- Enable and disable individual runners on projects