### PR TITLE
Get-GitLabProject - Fix always returning archived projects

### DIFF
--- a/PSGitLab/Public/Projects/Get-GitLabProject.ps1
+++ b/PSGitLab/Public/Projects/Get-GitLabProject.ps1
@@ -119,7 +119,10 @@ Function Get-GitLabProject {
         if ($archived) {
             $GetUrlParameters += @{archived='true'}
         }
-
+        else {
+            $GetUrlParameters += @{archived='false'}
+        }
+        
         if ($search -ne $null) {
             $GetUrlParameters += @{search=$search}
         }


### PR DESCRIPTION
Get-GitLabProject currently returns all projects including archived ones when the `archived` parameter is not specified.

This pull request changes that behavior so that archived projects are not returned unless the `archived` parameter switch is explicitly specified.