### PR TITLE
Improved user lookup

### DIFF
--- a/PSGitLab/Public/User/Block-GitLabUser.ps1
+++ b/PSGitLab/Public/User/Block-GitLabUser.ps1
@@ -24,18 +24,22 @@ Function Block-GitLabUser {
         Write-Verbose "$ID"
         switch ($PSCmdlet.ParameterSetName) {
             'ID' { $User = Get-GitLabUser -ID $ID }
-            'Email' { $User = Get-GitLabUser -ID $Email }
-            'Username' { $User = Get-GitLabUser -ID $Username }
+            'Email' { $User = Get-GitLabUser -Email $Email }
+            'Username' { $User = Get-GitLabUser -Username $Username }
         }
 
-        $request = @{
-            URI = "/users/$($User.ID)/block"
-            Method = 'POST'
-        }
+        if ($User -and $User.state -ne 'blocked') {
+            $request = @{
+                URI = "/users/$($User.ID)/block"
+                Method = 'POST'
+            }    
+            QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User' | Out-Null
+            if ($Passthru.IsPresent) {
+                Get-GitLabUser -ID $User.ID
+            }
 
-        $null = QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User'
-        if ($Passthru.IsPresent) {
-            Get-GitLabuser -id $User.ID
+        } elseif ($Passthru.IsPresent) {
+            $User
         }
 
     }

--- a/PSGitLab/Public/User/Get-GitLabUser.ps1
+++ b/PSGitLab/Public/User/Get-GitLabUser.ps1
@@ -3,7 +3,7 @@ Function Get-GitLabUser {
     [OutputType('GitLab.User')]
     param(
         [Parameter(ParameterSetName='ID')]
-        [string]$ID,
+        [int]$ID,
 
         [Parameter(ParameterSetName='All')]
         [switch]$All,
@@ -30,11 +30,13 @@ Function Get-GitLabUser {
 
     if ( $PSCmdlet.ParameterSetName -eq 'Username') {
 
-        QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User' | where-object { $_.username -eq $Username }
+        $Request.Body = @{'username' = $Username}
+        QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User'
 
     } elseif ( $PSCmdlet.ParameterSetName -eq 'Email') {
 
-        QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User' | where-object { $_.email -eq $email }
+        $Request.Body = @{'search' = $Email}
+        QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User'
 
     } else {
 

--- a/PSGitLab/Public/User/Remove-GitLabUser.ps1
+++ b/PSGitLab/Public/User/Remove-GitLabUser.ps1
@@ -1,29 +1,29 @@
 Function Remove-GitLabUser {
     [cmdletbinding(SupportsShouldProcess=$True,ConfirmImpact='High')]
     param(
-        [ValidateNotNull()]
         [ValidateNotNullOrEmpty()]
         [Parameter(Mandatory=$true,
                    ValueFromPipelineByPropertyName=$true)]
-        [string[]]$Username
+        [string]$Username
     )
 
     BEGIN {}
 
     PROCESS {
-        foreach ( $user in $Username ) {
+        $UserInfo = Get-GitLabUser -Username $Username
 
-            $UserInfo = (Get-GitLabUser -Username $User)[0]
+        if ($UserInfo) {
+
             Write-Verbose "$($UserInfo.Username)"
             $Request = @{
                 URI="/users/$($UserInfo.ID)"
                 Method = 'DELETE'
             }
-
-            if ( $PSCmdlet.ShouldProcess("Delete User $Username") ) {
-                $Results = QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User'
+    
+            if ( $PSCmdlet.ShouldProcess("Delete User $($UserInfo.Username)") ) {
+                QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User' | Out-Null
             }
-
+    
         }
 
     }

--- a/PSGitLab/Public/User/Unblock-GitLabUser.ps1
+++ b/PSGitLab/Public/User/Unblock-GitLabUser.ps1
@@ -24,18 +24,22 @@ Function Unblock-GitLabUser {
         Write-Verbose "$ID"
         switch ($PSCmdlet.ParameterSetName) {
             'ID' { $User = Get-GitLabUser -ID $ID }
-            'Email' { $User = Get-GitLabUser -ID $Email }
-            'Username' { $User = Get-GitLabUser -ID $Username }
+            'Email' { $User = Get-GitLabUser -Email $Email }
+            'Username' { $User = Get-GitLabUser -Username $Username }
         }
 
-        $request = @{
-            URI = "/users/$($User.ID)/unblock"
-            Method = 'POST'
-        }
+        if ($User -and $User.state -eq 'blocked') {
+            $request = @{
+                URI = "/users/$($User.ID)/unblock"
+                Method = 'POST'
+            }    
+            QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User' | Out-Null
+            if ($Passthru.IsPresent) {
+                Get-GitLabUser -ID $User.ID
+            }
 
-        $null = QueryGitLabAPI -Request $Request -ObjectType 'GitLab.User'
-        if ($Passthru.IsPresent) {
-            Get-GitLabuser -id $User.ID
+        } elseif ($Passthru.IsPresent) {
+            $User
         }
 
     }


### PR DESCRIPTION
Use `username` and `search` request parameter to get user by username or email instead of sending request for full list of users.