### PR TITLE
Suppress get project API call when querying commits

### DIFF
--- a/PSGitLab/Public/Projects/Get-GitLabProjectCommit.ps1
+++ b/PSGitLab/Public/Projects/Get-GitLabProjectCommit.ps1
@@ -29,7 +29,8 @@
   switch ($PSCmdlet.ParameterSetName) {
     'Id'
     {
-      $Project = Get-GitLabProject -Id $Id
+      # we avoid making the API call when the client provides a project ID
+      # $Project = Get-GitLabProject -Id $Id
     }
     'Namespace'
     {
@@ -55,7 +56,7 @@
   }
 
   $Request = @{
-    URI    = "/projects/$($Project.id)/repository/commits"
+    URI    = "/projects/$($Id)/repository/commits"
     Method = 'GET'
     Body   = $Body
   }


### PR DESCRIPTION
I created a script which was querying many thousands of commits.  I didn't like that each of these was triggering a secondary API call to query the project API

I've temporarily disabled the call trusting the provided Id, but other possible solutions include:
1) caching of projects
2) adding a `ValidateParameters` semantic and only call the project API if set