### PR TITLE
Create project based on template and allow namespace per full path

### DIFF
--- a/PSGitLab/Public/Configuration/Test-GitLabAPI.ps1
+++ b/PSGitLab/Public/Configuration/Test-GitLabAPI.ps1
@@ -1,7 +1,7 @@
 ﻿Function Test-GitLabAPI {
     param(
     [Parameter(Mandatory=$false)]
-    [string]$Version = 'v3'
+    [string]$Version = 'v4'
 )
     $GitLabConfig = ImportConfig
 

--- a/PSGitLab/Public/Projects/New-GitLabProject.ps1
+++ b/PSGitLab/Public/Projects/New-GitLabProject.ps1
@@ -27,7 +27,7 @@ Function New-GitLabProject {
 
     try {
         if ($PSBoundParameters.ContainsKey('Namespace')) {
-            $nSpace = Get-GitLabNamespace | Where-Object {$_.path -eq "$Namespace"}
+            $nSpace = Get-GitLabNamespace | Where-Object {$_.path -eq "$Namespace" -or $_.full_path -eq "$Namespace"}
             if ($nSpace.id.Count -eq 1) {
                 $Body.Add('namespace_id', $nSpace.id)
                 $PSBoundParameters.Remove('Namespace') | Out-Null

--- a/PSGitLab/Public/Projects/New-GitLabProject.ps1
+++ b/PSGitLab/Public/Projects/New-GitLabProject.ps1
@@ -18,6 +18,8 @@ Function New-GitLabProject {
         [Switch]$public,
         [ValidateSet("Private", "Internal", "Public")]
         [String]$visibility_level
+        [String]$template_name,
+        [boolean]$use_custom_template
     )
 
     $Body = @{


### PR DESCRIPTION
Add possibility to  : 

- Create project based on template (official or custom)
- Set the namespace parameter as name or path

Examples : 

```
New-GitLabProject -Path myproject -namespace mynamespace/repo
New-GitLabProject -Path myproject -namespace mynamespace/repo -template_name "myofficialtemplate" -use_custom_template $false
New-GitLabProject -Path myproject -namespace mynamespace/repo -template_name "mycustomtemplate" -use_custom_template $true
```


